### PR TITLE
vscodeのCodeSpellCheckerを導入し、設定ファイルを作成

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,5 @@
+{
+  // Version of the setting file.  Always 0.2
+  "version": "0.2",
+  "ignorePaths": [".cspell", ".github", ".vscode"]
+}

--- a/.cspell/dictionaries/common.txt
+++ b/.cspell/dictionaries/common.txt
@@ -1,0 +1,1 @@
+Repanic

--- a/.cspell/dictionaries/golang.txt
+++ b/.cspell/dictionaries/golang.txt
@@ -1,0 +1,1 @@
+sentrygin

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "eslint.workingDirectories": ["./frontend"],
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  }
+    "source.fixAll.eslint": "explicit"
+  },
+  "cSpell.words": ["Ginzap"]
 }

--- a/backend/.cspell.json
+++ b/backend/.cspell.json
@@ -12,7 +12,7 @@
       ]
     }
   ],
-  "dictionaries": ["common", "golang", "kubernetes"],
+  "dictionaries": ["common", "golang"],
   "dictionaryDefinitions": [
     {
       "name": "common",

--- a/backend/.cspell.json
+++ b/backend/.cspell.json
@@ -1,0 +1,27 @@
+{
+  // Version of the setting file.  Always 0.2
+  "version": "0.2",
+  "languageSettings": [
+    {
+      "languageId": "go",
+      "ignoreRegExpList": [
+        // ignore multiline imports
+        "import\\s*\\((.|[\r\n])*?\\)",
+        // ignore single line imports
+        "import\\s*.*\".*?\""
+      ]
+    }
+  ],
+  "dictionaries": ["common", "golang", "kubernetes"],
+  "dictionaryDefinitions": [
+    {
+      "name": "common",
+      "path": "../.cspell/dictionaries/common.txt"
+    },
+    {
+      "name": "golang",
+      "path": "../.cspell/dictionaries/golang.txt"
+    }
+  ],
+  "ignorePaths": [".cspell.json", ".golangci.yml"]
+}

--- a/frontend/cspell.json
+++ b/frontend/cspell.json
@@ -1,0 +1,20 @@
+{
+  // Version of the setting file.  Always 0.2
+  "version": "0.2",
+  "languageSettings": [
+    {
+      "languageId": "typescript"
+    }
+  ],
+  "dictionaries": ["common", "typescript"],
+  "dictionaryDefinitions": [
+    {
+      "name": "common",
+      "path": "../.cspell/dictionaries/common.txt"
+    },
+    {
+      "name": "typescript",
+      "path": "../.cspell/dictionaries/typescript.txt"
+    }
+  ]
+}


### PR DESCRIPTION
vscodeのCodeSpellCheckerを導入し、設定ファイルを作成
今後は誤ったスペルミス判定を辞書登録していく